### PR TITLE
Updated snippet for double encoding

### DIFF
--- a/core/components/twitterx/elements/snippets/snippet.TwitterX.php
+++ b/core/components/twitterx/elements/snippets/snippet.TwitterX.php
@@ -67,6 +67,7 @@ if (!function_exists('compareTweetsByDate')) {
 // Simple function to for use with array_map for sanitizing purposes.
 if (!function_exists('sanitize_array')) {
 	function sanitize_array($input) {
+		$input = html_entity_decode($input);
 		return htmlentities($input, ENT_QUOTES, 'UTF-8', false);
 	}
 }


### PR DESCRIPTION
ampersands & are getting double encoded. Added the decode prevents this
